### PR TITLE
Fix layout recreation check

### DIFF
--- a/core/java/android/widget/TextView.java
+++ b/core/java/android/widget/TextView.java
@@ -8668,7 +8668,7 @@ public class TextView extends View implements ViewTreeObserver.OnPreDrawListener
 
         mTextDir = getTextDirectionHeuristic();
 
-        if (mLayout != null) {
+        if (mLayout != null && mLayoutParams != null) {
             checkForRelayout();
         }
     }


### PR DESCRIPTION
Change I7d6b088a9235362e03cb6694392df71bbf5a323a added a relayout
for programmatic text direction changes, but this is breaking some
fixed layouts. Make sure layout params exist before trying to
act on them

Change-Id: Ibfe3daa71490d109c9a4bdc4c90cbf9517e53260
