### PR TITLE
Slim Heads up: change behaviour of back key

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
@@ -1701,7 +1701,7 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
         WindowManager.LayoutParams lp = new WindowManager.LayoutParams(
                 LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT,
                 WindowManager.LayoutParams.TYPE_STATUS_BAR_PANEL, // above the status bar!
-                WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL
+                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
                         | WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM
                         | WindowManager.LayoutParams.FLAG_WATCH_OUTSIDE_TOUCH
                         | WindowManager.LayoutParams.FLAG_SPLIT_TOUCH,

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/HeadsUpNotificationView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/HeadsUpNotificationView.java
@@ -22,7 +22,6 @@ import android.content.res.Configuration;
 import android.graphics.Rect;
 import android.util.AttributeSet;
 import android.util.Log;
-import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewConfiguration;
@@ -172,19 +171,6 @@ public class HeadsUpNotificationView extends FrameLayout implements SwipeHelper.
         return mSwipeHelper.onInterceptTouchEvent(ev)
                 || mExpandHelper.onInterceptTouchEvent(ev)
                 || super.onInterceptTouchEvent(ev);
-    }
-
-    @Override
-    public boolean dispatchKeyEvent(KeyEvent event) {
-        boolean down = event.getAction() == KeyEvent.ACTION_DOWN;
-        switch (event.getKeyCode()) {
-        case KeyEvent.KEYCODE_BACK:
-            if (!down) {
-                mBar.hideHeadsUp();
-            }
-            return true;
-        }
-        return super.dispatchKeyEvent(event);
     }
 
     // View methods


### PR DESCRIPTION
Currently back key hides the heads up. We change it that the back key is still
working for the app which has focus and not for the heads up at all.

Reasons:
1. A lot user requested this due that they often hide the heads up during they work
   on the phone, simply due that the back button is often pressed on a normal workflow.
   The results is indeed that a lot heads up windows are missed excidentaly.
2. First I thought to make it optional. But there is another big reason to do it this way. Current
   behaviour is that the heads up view gets focus...and that we dispatch the back key only. Thing is
   that other key events are still rooted to the heads up window. Well most things a user will not see.
   But eg on apps with input field some keys on the IME keyboard do not work during the heads up is showing
   which is a big no go when we assume that heads up needs to be as much non intrusive as possible.

That being said we remove the dispatch override and give the heads up window FLAG_NOT_FOCUSABLE flag
which will bypass any key events to the window behind which had focus before the heads up showed up.

FLAG_NOT_TOUCH_MODAL we can remove due that FLAG_NOT_FOCUSABLE automatically enables the FLAG_NOT_TOUCH_MODAL flag.

Change-Id: Ied4c7d2dd5b99f89af958f01db980a36d431bbc3
